### PR TITLE
Add MCP server configuration to agent setup

### DIFF
--- a/universalagent/agents/entrypoint.py
+++ b/universalagent/agents/entrypoint.py
@@ -14,7 +14,7 @@ from typing import List, Optional, Dict, Any, Callable
 from universalagent.agents.handler.silencetimeouthandler import SilenceTimeoutHandler
 from universalagent.events.event_sender import EventSender
 from livekit import agents
-from livekit.agents import AgentSession, RoomInputOptions, JobContext
+from livekit.agents import AgentSession, RoomInputOptions, JobContext, mcp
 from livekit.agents import BackgroundAudioPlayer, AudioConfig, BuiltinAudioClip
 from livekit.agents import metrics, MetricsCollectedEvent
 from livekit.agents import JobProcess
@@ -157,6 +157,9 @@ async def start_agent_session(ctx: JobContext, config: AgentConfig, meta: CallMe
             "memory_manager": ctx.proc.userdata.get("memory_manager"),
         }
 
+        # create mcp servers
+        mcp_servers = [mcp.MCPServerHTTP(url=mcp_server.url, headers=mcp_server.headers) for mcp_server in config.mcp_servers]
+
         # Create AgentSession
         session = AgentSession(
             stt=stt,
@@ -165,6 +168,7 @@ async def start_agent_session(ctx: JobContext, config: AgentConfig, meta: CallMe
             vad=ctx.proc.userdata["vad"],
             turn_detection=turn_detection,
             userdata=session_userdata,
+            mcp_servers=mcp_servers,
         )
 
         # Create room input options with noise cancellation

--- a/universalagent/core/config.py
+++ b/universalagent/core/config.py
@@ -207,6 +207,12 @@ class WebhookConfig:
 
 
 @dataclass
+class McpConfig:
+    """Configuration for MCP servers."""
+    url: str
+    headers: Optional[Dict[str, str]] = None
+
+@dataclass
 class AgentConfig:
     """Main configuration for a configurable agent."""
 
@@ -239,6 +245,9 @@ class AgentConfig:
 
     # Tools & Capabilities
     tools: List[ToolConfig] = field(default_factory=list)
+
+    # MCP Servers
+    mcp_servers: List[McpConfig] = field(default_factory=list)
 
     # evaluation criteria
     evaluation_criteria: List[EvaluationCriteria] = field(default_factory=list)
@@ -325,6 +334,11 @@ class AgentConfig:
         for tool_data in data.get("tools", []):
             tools.append(ToolConfig(**tool_data))
 
+        # Parse MCP servers
+        mcp_servers = []
+        for mcp_data in data.get("mcp_servers", []):
+            mcp_servers.append(McpConfig(**mcp_data))
+
         # Parse webhooks
         evaluation_webhook = None
         if data.get("evaluation_webhook"):
@@ -365,6 +379,7 @@ class AgentConfig:
             silence_timeout=data.get("silence_timeout"),
             interruption_handling=data.get("interruption_handling", True),
             noise_cancellation=data.get("noise_cancellation", "BVC"),
+            mcp_servers=mcp_servers,
         )
 
     @classmethod


### PR DESCRIPTION
Introduces a new McpConfig class for MCP server settings and updates the AgentConfig to include a list of MCP servers. Modifies the start_agent_session function to create MCP server instances based on the provided configuration.